### PR TITLE
Fix a 'unknown operand' warning in docker-enter

### DIFF
--- a/docker-enter
+++ b/docker-enter
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -z "$@" ]; then
+if [ -z "$1" ]; then
     echo "usage: docker-enter <container id/name> <command to run default:sh>"
 else
     PID=$(docker inspect --format {{.State.Pid}} "$1")


### PR DESCRIPTION
The commit says it all...

This is the kind of warning you get when adding additional operands:

```
$ docker-enter $(docker ps -q -n -1) /bin/bash
sh: /bin/bash: unknown operand
root@60428207baf8:/#
```

PS: thanks for it and your blog article!
