### PR TITLE
Exiting early if container is not found

### DIFF
--- a/docker-enter
+++ b/docker-enter
@@ -4,6 +4,9 @@ if [ -z "$1" ]; then
     echo "usage: docker-enter <container id/name> <command to run default:sh>"
 else
     PID=$(docker inspect --format {{.State.Pid}} "$1")
+    if [ -z "$PID" ]; then
+        exit 1
+    fi
     shift
     nsenter --target $PID --mount --uts --ipc --net --pid -- "$@"
 fi


### PR DESCRIPTION
Before:

```
# docker-enter b
Error: No such image or container: b
nsenter: failed to parse pid: '--mount'
```

Now:

```
# docker-enter b
Error: No such image or container: b
```
