### PR TITLE
Use full path to nsenter in docker-enter

### DIFF
--- a/docker-enter
+++ b/docker-enter
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+NSENTER=$(dirname "$0")/nsenter
+
 if [ -z "$1" ]; then
     echo "usage: docker-enter <container id/name> <command to run default:sh>"
 else
@@ -8,5 +10,5 @@ else
         exit 1
     fi
     shift
-    nsenter --target $PID --mount --uts --ipc --net --pid -- "$@"
+    "$NSENTER" --target $PID --mount --uts --ipc --net --pid -- "$@"
 fi


### PR DESCRIPTION
I was trying to use docker-enter for the first time under boot2docker and got this error:

```
/var/lib/boot2docker/docker-enter: line 12: nsenter: not found
2014/07/15 09:13:20 exit status 127
```

I updated the docker-enter script to get the full path to nsenter based on the dirname of docker-enter itself.
