### PR TITLE
Improved detection of available shell in container (fixes #5)

### DIFF
--- a/docker-enter
+++ b/docker-enter
@@ -3,22 +3,27 @@
 NSENTER=$(dirname "$0")/nsenter
 
 if [ -z "$1" ]; then
-    echo "usage: docker-enter <container id/name> <command to run default:bash>"
+    echo "Usage: docker-enter CONTAINER [COMMAND [ARG]...]"
+    echo ""
+    echo "Enters the Docker CONTAINER and executes the specified COMMAND."
+    echo "If COMMAND is not specified, runs an interactive shell in CONTAINER."
 else
-    PID=$(docker inspect --format {{.State.Pid}} "$1")
+    PID=$(docker inspect --format "{{.State.Pid}}" "$1")
     if [ -z "$PID" ]; then
         exit 1
     fi
     shift
 
-    OPTS="--target $PID --mount --uts --ipc --net --pid -- env --ignore-environment --"
+    OPTS="--target $PID --mount --uts --ipc --net --pid --"
 
     if [ -z "$1" ]; then
-        # No command given. Use su to log in to the 
-        # containers default shell and set up the environment, 
-        # including $HOME, $PATH etc.
+        # No command given.
+        # Use su to clear all host environment variables except for TERM,
+        # initialize the environment variables HOME, SHELL, USER, LOGNAME, PATH,
+        # and start a login shell.
         "$NSENTER" $OPTS su - root
     else
-        "$NSENTER" $OPTS "$@"
+        # Use env to clear all host environment variables.
+        "$NSENTER" $OPTS env --ignore-environment -- "$@"
     fi
 fi


### PR DESCRIPTION
docker-enter tried to open the same shell inside the container as on
the host, which failed if the container did not _have_ that shell.

Additionally, (environment) variables of the host were also present in
the nsenter session.

This change;
1. Checks if a command was given as parameter
2. If no command, check if ‘bash’ is present inside the container
3. Otherwise use ‘sh’ as shell

As discussed here; https://github.com/jpetazzo/nsenter/issues/5
