### PR TITLE
Don't assume nsenter and docker-enter are in the same directory

### DIFF
--- a/docker-enter
+++ b/docker-enter
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-NSENTER=$(dirname "$0")/nsenter
+if [ -e $(dirname "$0")/nsenter ]; then
+    # with boot2docker, nsenter is not in the PATH but it is in the same folder
+    NSENTER=$(dirname "$0")/nsenter
+else
+    NSENTER=nsenter
+fi
 
 if [ -z "$1" ]; then
     echo "Usage: docker-enter CONTAINER [COMMAND [ARG]...]"


### PR DESCRIPTION
In coreos, `nsenter` is built-in and installed in the read-only
partition as `/usr/bin/nsenter`.
A systemd service must not installs docker-enter in `/usr/bin`.

This change makes sure that we force the full path of nsenter if and
only if it exists in the same directory.
I am not sure why the full path was needed in the first place:
it works without it in coreos.
