### PR TITLE
Add -t to boot2docker ssh for creating a tty

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If you are using boot2docker, you can use the function below, to:
 ```
 docker-enter() {
   boot2docker ssh '[ -f /var/lib/boot2docker/nsenter ] || docker run --rm -v /var/lib/boot2docker/:/target jpetazzo/nsenter'
-  boot2docker ssh sudo /var/lib/boot2docker/docker-enter "$@"
+  boot2docker ssh -t sudo /var/lib/boot2docker/docker-enter "$@"
 }
 ```
 


### PR DESCRIPTION
Without `-t` in the boot2docker alias, at least I get the error message 

```
stdin: is not a tty
```
