### PR TITLE
Preserve the container's root process environment

### DIFF
--- a/docker-enter
+++ b/docker-enter
@@ -14,12 +14,9 @@ if [ -z "$1" ]; then
     echo "If COMMAND is not specified, runs an interactive shell in CONTAINER."
 else
     PID=$(docker inspect --format "{{.State.Pid}}" "$1")
-    if [ -z "$PID" ]; then
-        exit 1
-    fi
+    [ -z "$PID" ] && exit 1
     shift
-
-    OPTS="--target $PID --mount --uts --ipc --net --pid --"
+    COMMAND="$@"
 
     if [ "$(id -u)" -ne "0" ]; then
         which sudo > /dev/null
@@ -29,15 +26,17 @@ else
           echo "Warning: Cannot find sudo; Invoking nsenter as the user $USER." >&2
         fi
     fi
+    
+    # Get environment variables from the container's root process
+    ENV=$(sudo cat /proc/$PID/environ | xargs -0)
+    
+    # If no command is given, default to `su` which executes the default login shell
+    # Otherwise, execute the given command
+    [ -z "$COMMAND" ] && COMMAND="su -m root"
+    
+    # Prepare nsenter flags
+    OPTS="--target $PID --mount --uts --ipc --net --pid --"
 
-    if [ -z "$1" ]; then
-        # No command given.
-        # Use su to clear all host environment variables except for TERM,
-        # initialize the environment variables HOME, SHELL, USER, LOGNAME, PATH,
-        # and start a login shell.
-        $LAZY_SUDO "$NSENTER" $OPTS su - root
-    else
-        # Use env to clear all host environment variables.
-        $LAZY_SUDO "$NSENTER" $OPTS env --ignore-environment -- "$@"
-    fi
+    # Use env to clear all host environment variables and set then anew
+    $LAZY_SUDO "$NSENTER" $OPTS env -i - $ENV $COMMAND
 fi


### PR DESCRIPTION
Fixes #18, when entering a container, the environment is preserved:

``` console
kolypto@localhost% ./docker-enter myapp   env | fgrep DB_1_PORT_5432_TCP_ADDR 
DB_1_PORT_5432_TCP_ADDR=172.17.0.63
```

It also works as a login shell, without the command:

``` console
kolypto@localhost% docker-enter myapp
root@b6b93bc18ec2:/# env | fgrep DB_1_PORT_5432_TCP_ADDR       
DB_1_PORT_5432_TCP_ADDR=172.17.0.63
```

(that means, `bash` is not hardcoded).

Also did a bit of refactoring on the code, but nothing serious:
- Replaced `if [ ... ] ; then .. fi` with `[ ... ] && ...`
- Put `$1` into `$COMMAND`
- Refactored `if [ -z "$1" ]; then` into setting a default value for `$COMMAND`

@jpetazzo , what do you think?
