### PR TITLE
Fix. can't enter the wrong environ container

### DIFF
--- a/docker-enter
+++ b/docker-enter
@@ -28,7 +28,7 @@ else
     fi
     
     # Get environment variables from the container's root process
-    ENV=$(sudo cat /proc/$PID/environ | xargs -0)
+    ENV=$(sudo cat /proc/$PID/environ | xargs -0 | grep =)
     
     # If no command is given, default to `su` which executes the default login shell
     # Otherwise, execute the given command
@@ -38,5 +38,9 @@ else
     OPTS="--target $PID --mount --uts --ipc --net --pid --"
 
     # Use env to clear all host environment variables and set then anew
-    $LAZY_SUDO "$NSENTER" $OPTS env -i - $ENV $COMMAND
+    if [ -z "$ENV" ]; then
+        $LAZY_SUDO "$NSENTER" $OPTS $COMMAND
+    else
+        $LAZY_SUDO "$NSENTER" $OPTS env -i - $ENV $COMMAND
+    fi
 fi


### PR DESCRIPTION
When I enter the nginx container it raise an expection

    env: master: No such file or directory

then I `cat /proc/$PID/environ`, I find nginx set it's environ `master process nginx`,  it's a wrong env value