### PR TITLE
Remove usage of which and use command instead

### DIFF
--- a/docker-enter
+++ b/docker-enter
@@ -18,14 +18,14 @@ else
     shift
 
     if [ "$(id -u)" -ne "0" ]; then
-        which sudo > /dev/null
+        command -v sudo > /dev/null 2>&1
         if [ "$?" -eq "0" ]; then
           LAZY_SUDO="sudo "
         else
           echo "Warning: Cannot find sudo; Invoking nsenter as the user $USER." >&2
         fi
     fi
-    
+
     # Get environment variables from the container's root process
 
     ENV=$($LAZY_SUDO cat /proc/$PID/environ | xargs -0)


### PR DESCRIPTION
Command is POSIX compliant with a defined exit status (unlike which).
Which was not installed on the system I was using, so relying on a
builtin really is much safer. Further commentary here:

http://stackoverflow.com/questions/592620/how-to-check-if-a-program-exists-from-a-bash-script

Also removed some unnecessary whitespace.
