### PR TITLE
Update to util-linux v.2.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:jessie
-ENV VERSION 2.25
+ENV VERSION 2.26
 RUN apt-get update -q
 RUN apt-get install -qy curl build-essential
 RUN mkdir /src


### PR DESCRIPTION
Full changelog @ https://www.kernel.org/pub/linux/utils/util-linux/v2.26/v2.26-ReleaseNotes . 
Some highlights;
```
nsenter(1):
 - has been updated to work with the latest kernel changes in user namespaces
 - supports new command-line option --preserve-credentials

unshare(1):
 - has been updated to work with the latest kernel changes in user namespaces
 - supports new command-line option "--setgroups=<deny|allow>"
```