### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ You can use it directly from your host (OS X/Windows), no need to ssh into boot2
   container (yet).
 
 
-[container namespaces]: http://blog.dotcloud.com/under-the-hood-linux-kernels-on-dotcloud-part
+[container namespaces]: https://gun.io/blog/PaaS-under-the-hood-episode-1-kernel-namespaces/
 [enter into a Docker container]: http://jpetazzo.github.io/2014/03/23/lxc-attach-nsinit-nsenter-docker-0-9/
 [Debugging a Docker container]: http://blog.loof.fr/2014/06/debugging-docker-container.html
 [Nicolas De Loof]: https://twitter.com/ndeloof


### PR DESCRIPTION
The link to [container namespaces](http://blog.dotcloud.com/under-the-hood-linux-kernels-on-dotcloud-part) seems gone, but it appears to be mirrored at [gun.io](https://gun.io/blog/PaaS-under-the-hood-episode-1-kernel-namespaces/).

For the record, the same link was [replaced](https://github.com/docker/docker/pull/14244/commits/9bbdaa9280609c2c6fc86c6749dfb3d4869d0097) in the Docker README with a [different link](http://man7.org/linux/man-pages/man7/namespaces.7.html).