### PR TITLE
Fix util-linux download step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -q
 RUN apt-get install -qy curl build-essential
 RUN mkdir /src
 WORKDIR /src
-RUN curl https://www.kernel.org/pub/linux/utils/util-linux/v$VERSION/util-linux-$VERSION.tar.gz \
+RUN curl -L https://www.kernel.org/pub/linux/utils/util-linux/v$VERSION/util-linux-$VERSION.tar.gz \
      | tar -zxf-
 RUN ln -s util-linux-$VERSION util-linux
 WORKDIR /src/util-linux


### PR DESCRIPTION
Currently, building the docker image fail at step 7/19 (downloading and dezipping `util-linux`) with:
> gzip: stdin: not in gzip format

Basically, I received 301 HTTP status code. So, this fix apply the `-L` flag to the curl command to follow any redirect while downloading the kernel util-linux.